### PR TITLE
Introduce a Set-Get benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ coverage: out/report.json ## Displays coverage per func on cli
 html-coverage: out/report.json ## Displays the coverage results in the browser
 	go tool cover -html=out/cover.out
 
+benchmark: ## Runs all benchmarks
+	go test -bench=. -count 5 | tee out/new-bench.txt
+
 test-reports: out/report.json
 
 .PHONY: out/report.json

--- a/store_test.go
+++ b/store_test.go
@@ -70,3 +70,21 @@ func TestKVStore_Delete(t *testing.T) {
 	}
 
 }
+
+// pkg: github.com/tech-branch/tbkv@v1.0.0
+// cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
+// BenchmarkMultipleSetGets-8   	  649632	      1666 ns/op	     232 B/op	       3 allocs/op
+func BenchmarkMultipleSetGets(b *testing.B) {
+	kvs := NewDefaultStore()
+	const (
+		key = "key"
+		val = "value"
+	)
+	for i := 0; i < b.N; i++ {
+		kvs.Set(key, val)
+		_, err := kvs.Get(key)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
Implements a simple Set->Get benchmark against TBKV

Prior to this change, it wasn't easily possible to measure the performance of the store.